### PR TITLE
Added support for TunnelServer to bind to specific local IP

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,13 @@ jobs:
             - ~/.m2
           key: v1-dependencies-{{ checksum "pom.xml" }}
 
-      - run: mvn package jacoco:report coveralls:report -DrepoToken=${repoToken}
+      - run:
+          name: Execute Maven to clean, compile, test, and package
+          command: mvn clean package
+
+      - run:
+          name: Execute Maven to create JaCoCo report and submit Coveralls data
+          command: mvn jacoco:report coveralls:report -DrepoToken=${repoToken}
 
       - run:
           name: Save test results
@@ -51,6 +57,7 @@ jobs:
             mkdir -p ~/surefire-reports/
             find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/surefire-reports/ \;
           when: always
+
       - store_test_results:
           path: ~/surefire-reports
 
@@ -60,5 +67,6 @@ jobs:
             mkdir -p ~/package/
             find . -type f -regex ".*/target/.*jar" -exec cp {} ~/package/ \;
           when: always
+
       - store_artifacts:
           path: ~/package

--- a/configs/defaults.conf
+++ b/configs/defaults.conf
@@ -11,13 +11,14 @@ remoteServers = [
     port = 7152
     hostname = "edge.ny4.kenrui.com"
     description = "edgeny4"
-  },
-  {
-    ip = "127.0.0.1"
-    port = 7152
-    hostname = "campus.sz.kenrui.com"
-    description = "campussz"
   }
+//  ,
+//  {
+//    ip = "127.0.0.1"
+//    port = 7152
+//    hostname = "campus.sz.kenrui.com"
+//    description = "campussz"
+//  }
 ]
 
 //RAM size for MetaApp 32 = 4294967296 Bytes

--- a/src/main/java/com/kenrui/packetbroker/config/AppConfig.java
+++ b/src/main/java/com/kenrui/packetbroker/config/AppConfig.java
@@ -20,6 +20,8 @@ import org.springframework.context.annotation.Configuration;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.nio.channels.Selector;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
@@ -147,7 +149,7 @@ public class AppConfig {
 
     @Bean
     public TunnelServer tunnelServer() throws IOException {
-        return new TunnelServer(localServerEndpoint().getPort(),
+        return new TunnelServer(localServerEndpoint(),
                 messageQueueToRemoteClients(),
                 packetsToResendQueue(),
                 remoteClients(),

--- a/src/test/java/com/kenrui/packetbroker/clientserver/TunnelServerTest.java
+++ b/src/test/java/com/kenrui/packetbroker/clientserver/TunnelServerTest.java
@@ -237,7 +237,7 @@ public class TunnelServerTest extends AbstractTestNGSpringContextTests {
 //        Mockito.doReturn(keySet).when(selector).selectedKeys();
 
         // Create a handler thread for testing and spy it
-        tunnelServerThread = Mockito.spy(new TunnelServer(localServerEndpoint.getPort(), messageQueueToRemoteClients,
+        tunnelServerThread = Mockito.spy(new TunnelServer(localServerEndpoint, messageQueueToRemoteClients,
                 packetsToResendQueue, remoteClients, resend, selector, serverSocketChannel, packetUtils));
     }
 


### PR DESCRIPTION
Added support to bind TunnelServer to a specific local IP.  Previously it was binding to the any address (0.0.0.0/0).  A choice was made to use IP rather than interface name because it is possible to have multiple IPs assigned on an interface.